### PR TITLE
Update element selector

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
   },
   "homepage": "https://github.com/isAdrisal/revelio#readme",
   "scripts": {
-    "build": "npm run build:es5 & npm run build:cjs",
+    "build": "yarn run build:es5 & yarn run build:cjs",
     "build:es5": "mkdir -p dist && babel revelio.js --out-file dist/revelio.es5.js",
     "build:cjs": "mkdir -p dist && babel --no-babelrc revelio.js --out-file dist/revelio.cjs.js",
-    "deploy": "yarn build && npm publish"
+    "deploy": "yarn build && yarn publish"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "revelio",
-  "version": "0.0.2",
+  "version": "0.0.5",
   "description": "A very small library to reveal elements on scroll using an IntersectionObserver and CSS.",
   "main": "dist/revelio.cjs.js",
   "module": "revelio.js",

--- a/revelio.js
+++ b/revelio.js
@@ -10,8 +10,8 @@ const revelio = () => {
   variables.rootMargin = variables.root && window.revelioConfig && window.revelioConfig.rootMargin || null;
   variables.threshold = window.revelioConfig && window.revelioConfig.threshold || 0.25;
 
-  // Find all DOM elements with [data-revelio] attribute. Return if none.
-  const animatedElements = document.querySelectorAll('[data-revelio]');
+  // Find all DOM elements with non-empty [data-revelio] attribute. Return if none.
+  const animatedElements = document.querySelectorAll('[data-revelio]:not([data-revelio=""])');
   if (animatedElements.length < 1) { return };
   
   // Don't hide content from Google; no IntersectionObserver fallback.


### PR DESCRIPTION
Updates element selector to exclude empty `[data-revelio]` attributes. This means we don't attach an InsersectionObserver to these excluded elements.

Reduces unnecessary memory and CPU usage when `revelio()` is called after a DOM update.

